### PR TITLE
hopefully fixed extraneous cssfiles fragment in myprofile.html

### DIFF
--- a/src/main/resources/templates/myprofile.html
+++ b/src/main/resources/templates/myprofile.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
     <head th:replace="fragments/head.html :: head"></head>
-    <th:block th:replace="fragments/cssfiles.html :: cssfiles"></th:block>
     <body>
 <!--        this extra container is necessary for the footer to stay at the bottom-->
         <div class="body">


### PR DESCRIPTION
- fixed left-over fragment "cssfiles.html" that doesn't exist in repo

Whitelabel Error Page
This application has no explicit mapping for /error, so you are seeing this as a fallback.

Thu Apr 16 20:34:22 UTC 2020
There was an unexpected error (type=Internal Server Error, status=500).
Error resolving template [fragments/cssfiles.html], template might not exist or might not be accessible by any of the configured Template Resolvers (template: "myprofile" - line 4, col 15)